### PR TITLE
feature: create dropdown rough drafts with mock data

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import { Route, Routes } from "react-router-dom";
-import { createTheme } from '@mui/material/styles';
-import { ThemeProvider } from "@mui/material/styles";
+import { createTheme } from "@mui/material/styles";
+import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
 
 import LearnPage from "./components/LearnPage";
 import HomePage from "./components/HomePage";
@@ -23,25 +23,30 @@ const THEME = createTheme({
 
 function App() {
   return (
-    <ThemeProvider theme={THEME}>
-      <Header />
-      <div className="App">
-        <Routes>
-          <Route path="/" element={<HomePage />}></Route>
-          <Route path="/bills" element={<BillList />}></Route>
-          <Route path="/learn" element={<LearnPage />}></Route>
-          <Route path="/advanced" element={<AdvancedPage />}></Route>
-          <Route path="/about" element={<AboutPage />}></Route>
-          <Route
-            path="/assembly/:memberName"
-            element={<AssemblyMember />}
-          ></Route>
-          <Route path="/senate/:senatorName" element={<Senator />}></Route>
-          <Route path="/bill/:sessionYear/:printNo" element={<Bill />}></Route>
-        </Routes>
-      </div>
-      <Footer />
-    </ThemeProvider>
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={THEME}>
+        <Header />
+        <div className="App">
+          <Routes>
+            <Route path="/" element={<HomePage />}></Route>
+            <Route path="/bills" element={<BillList />}></Route>
+            <Route path="/learn" element={<LearnPage />}></Route>
+            <Route path="/advanced" element={<AdvancedPage />}></Route>
+            <Route path="/about" element={<AboutPage />}></Route>
+            <Route
+              path="/assembly/:memberName"
+              element={<AssemblyMember />}
+            ></Route>
+            <Route path="/senate/:senatorName" element={<Senator />}></Route>
+            <Route
+              path="/bill/:sessionYear/:printNo"
+              element={<Bill />}
+            ></Route>
+          </Routes>
+        </div>
+        <Footer />
+      </ThemeProvider>
+    </StyledEngineProvider>
   );
 }
 

--- a/frontend/src/components/HomePage/Card.jsx
+++ b/frontend/src/components/HomePage/Card.jsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 
 import CategoryTag from "../Category/CategoryTag";
+import { TAGS } from '../../constants';
 
 // TODO replace with actual categories when available
 function generateRandomTags() {
-  const tags = ["Climate", "Social Justice", "Education", "LGBTQ"];
+  const tags = TAGS.slice();
   const numTags = Math.floor(Math.random() * 2) + 1; // Generates either 1 or 2
   const randomTags = [];
 

--- a/frontend/src/components/HomePage/Dropdown.css
+++ b/frontend/src/components/HomePage/Dropdown.css
@@ -1,0 +1,16 @@
+.dropdown {
+    display: inline-flex;
+    flex-direction: column;
+    margin-right: 24px;
+}
+
+.dropdown-options {
+    width: 150px;
+    height: 40px;
+}
+
+/* override selected options preview styling */
+.MuiSelect-select, .dropdown-option {
+    font-family: var(--text-font);
+    font-size: 1em;
+}

--- a/frontend/src/components/HomePage/Dropdown.jsx
+++ b/frontend/src/components/HomePage/Dropdown.jsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { InputLabel, Select, MenuItem } from "@mui/material";
+
+// TODO: use MUI multiple select
+// TODO: styles
+const Dropdown = ({ id, label, options }) => {
+  const [selected, setSelected] = useState([]);
+
+  const updateSelected = (event) => {
+    setSelected(event.target.value);
+  };
+
+  return (
+    <div className="dropdown">
+      <InputLabel htmlFor={id} className="dropdown-label">
+        {label}
+      </InputLabel>
+      <Select
+        id={id}
+        className="dropdown-options"
+        multiple
+        value={selected}
+        onChange={updateSelected}
+      >
+        {options.map((option) => (
+          <MenuItem className="dropdown-option" value={option} key={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </Select>
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/frontend/src/components/HomePage/Dropdown.jsx
+++ b/frontend/src/components/HomePage/Dropdown.jsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { InputLabel, Select, MenuItem } from "@mui/material";
+import { Select, MenuItem } from "@mui/material";
 
-// TODO: use MUI multiple select
-// TODO: styles
+import "./Dropdown.css";
+
 const Dropdown = ({ id, label, options }) => {
   const [selected, setSelected] = useState([]);
 
@@ -12,12 +12,12 @@ const Dropdown = ({ id, label, options }) => {
 
   return (
     <div className="dropdown">
-      <InputLabel htmlFor={id} className="dropdown-label">
+      <label htmlFor={id} className="dropdown-label">
         {label}
-      </InputLabel>
+      </label>
       <Select
-        id={id}
         className="dropdown-options"
+        id={id}
         multiple
         value={selected}
         onChange={updateSelected}

--- a/frontend/src/components/HomePage/Filters.css
+++ b/frontend/src/components/HomePage/Filters.css
@@ -1,0 +1,4 @@
+.filters-bar {
+    display: inline-flex;
+    flex-direction: row;
+}

--- a/frontend/src/components/HomePage/Filters.jsx
+++ b/frontend/src/components/HomePage/Filters.jsx
@@ -1,0 +1,32 @@
+import { TAGS, BILL_STATUSES } from "../../constants";
+import Dropdown from "./Dropdown";
+import "./Filters.css";
+
+const Options = ({ options }) =>
+  options.map((option) => (
+    <option key={option} value={option}>
+      {option}
+    </option>
+  ));
+
+const Filters = () => (
+  <div className="filters-bar">
+    <Dropdown
+      id="legislator-select"
+      label="Legislator Name"
+      options={["Alex", "Bo", "Carly"]}
+    />
+    <Dropdown
+      id="status-select"
+      label="Bill Status"
+      options={Object.values(BILL_STATUSES)}
+    />
+    <Dropdown
+      id="category-select"
+      label="Bill Category"
+      options={TAGS}
+    />
+  </div>
+);
+
+export default Filters;

--- a/frontend/src/components/HomePage/Filters.jsx
+++ b/frontend/src/components/HomePage/Filters.jsx
@@ -1,16 +1,11 @@
+import { FormControl } from '@mui/material';
+
 import { TAGS, BILL_STATUSES } from "../../constants";
 import Dropdown from "./Dropdown";
 import "./Filters.css";
 
-const Options = ({ options }) =>
-  options.map((option) => (
-    <option key={option} value={option}>
-      {option}
-    </option>
-  ));
-
 const Filters = () => (
-  <div className="filters-bar">
+  <FormControl className="filters-bar" fullWidth>
     <Dropdown
       id="legislator-select"
       label="Legislator Name"
@@ -26,7 +21,7 @@ const Filters = () => (
       label="Bill Category"
       options={TAGS}
     />
-  </div>
+  </FormControl>
 );
 
 export default Filters;

--- a/frontend/src/components/HomePage/index.jsx
+++ b/frontend/src/components/HomePage/index.jsx
@@ -3,6 +3,7 @@ import './HomePage.css';
 
 import Card from './Card';
 import Banner from './Banner';
+import Filters from './Filters';
 
 const HomePage = () => {
   const [bills, setBills] = useState([]);
@@ -29,6 +30,7 @@ const HomePage = () => {
       <Banner />
       <div id='home-page'>
         <h1>Sunrise featured bills</h1>
+        <Filters />
         <div id='home-bill-grid'>
           {bills.map(bill => <Card bill={bill} key={bill.basePrintNoStr} />)}
         </div>

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,0 +1,11 @@
+export const TAGS = ["Climate", "Social Justice", "Education", "LGBTQ"];
+
+export const BILL_STATUSES = {
+    INTRODUCED: 'Introduced',
+    IN_COMMITTEE: 'In Committee',
+    ON_FLOOR_CALENDAR: 'On Floor Calendar',
+    PASSED_SENATE: 'Passed Senate',
+    PASSED_ASSEMBLY: 'Passed Assembly',
+    DELIVER_TO_GOVERNOR: 'Deliver to Governor',
+    SIGNED_BY_GOVERNOR: 'Signed By Governor',
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -360,6 +360,8 @@ template {
   --highlight-lgreen: #e6feb1;
   --highlight-lyellow: #f2deb8;
   --highlight-lred: #e4c3c3;
+  --h-text-font: "Fjalla One", sans-serif;
+  --text-font: "DM Mono", monospace;
 }
 
 * {
@@ -368,7 +370,7 @@ template {
 
 html {
   font-size: 10px;
-  font-family: "DM Mono", monospace;
+  font-family: var(--text-font);
 }
 
 body {
@@ -383,7 +385,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: "Fjalla One", sans-serif;
+  font-family: var(--h-text-font);
   letter-spacing: -0.01em;
 }
 


### PR DESCRIPTION
current state:
<img width="571" alt="Screen Shot 2024-03-01 at 4 33 37 PM" src="https://github.com/sunrisemvmtnyc/legislation-tracker/assets/8894579/05270766-131f-49da-a48f-f819ee7f285d">

notes:
- using `material-ui` components: `Select` + `MenuItem`
  - deferring to MUI library since likely already has tab navigation built in, for a11y purposes
- using CSS to custom style MUI elements
  - using following provider to ensure MUI styles don't overrule ours:

```
 return (
    <StyledEngineProvider injectFirst>
      {/* Your component tree. Now you can override Material UI's styles. */}
    </StyledEngineProvider>
  );
```

still todo:
- connect dropdowns to filtering