### PR TITLE
fix: Handle double-mount/request in dev/strict mode

### DIFF
--- a/frontend/src/components/HomePage/Card.jsx
+++ b/frontend/src/components/HomePage/Card.jsx
@@ -28,7 +28,6 @@ const Card = ({ bill }) => {
           <div className='home-bill-categories'>
             {
               categories.map(category => <CategoryTag category={category} key={category} />)
-              // categories.map(category => <CategoryTag category={category} key={`${bill.basePrintNoStr}:${category}`} />)
             }
           </div>
         )

--- a/frontend/src/components/HomePage/Card.jsx
+++ b/frontend/src/components/HomePage/Card.jsx
@@ -28,6 +28,7 @@ const Card = ({ bill }) => {
           <div className='home-bill-categories'>
             {
               categories.map(category => <CategoryTag category={category} key={category} />)
+              // categories.map(category => <CategoryTag category={category} key={`${bill.basePrintNoStr}:${category}`} />)
             }
           </div>
         )

--- a/frontend/src/components/HomePage/index.jsx
+++ b/frontend/src/components/HomePage/index.jsx
@@ -37,7 +37,6 @@ const HomePage = () => {
       setBills([])
       abortController.abort()
     }
-    // console.log('running useeffect'
   }, []); // Only run on initial page load
 
   return (


### PR DESCRIPTION
To repro:
On `main`:
1. Spin up environment
2. Visit environment, open network tab, reload
3. Note that api `/api/v1/bills/2023/search?offset=1` is called twice
4. Search page for "Homelessness Awareness" & note that the same bill shows twice

On this branch:
Follow the same steps. The API call will still be made twice, but the bill will not show up twice. To learn more, visit SO answer linked in commented code.