### PR TITLE
feat: Related committee-members of bills

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,6 @@ version: '3'
 services:
 
   frontend:
-    labels:
-      shipyard.route: '/'
     build: 'frontend'
     environment:
       CI: 'true'
@@ -15,13 +13,12 @@ services:
       - '5173:5173'
 
   backend:
-    labels:
-      shipyard.route: '/api'
     build: 'backend'
     environment:
       DEBUG: 'app'
       OPEN_LEGISLATION_KEY: ${OPEN_LEGISLATION_KEY}
       OPEN_STATES_KEY: ${OPEN_STATES_KEY}
+      # DEBUG: express:*
     volumes:
       - './backend/src:/srv/src'
     ports:

--- a/frontend/src/components/Bill/Bill.jsx
+++ b/frontend/src/components/Bill/Bill.jsx
@@ -2,10 +2,23 @@ import { PropTypes } from 'prop-types';
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
+function getSponsorNumber(billData) {
+  const {
+    activeVersion,
+    amendments: { items },
+  } = billData;
+  return (
+    1 +
+    items[activeVersion].coSponsors.size +
+    items[activeVersion].multiSponsors.size
+  );
+}
+
 const RelatedBills = ({ related }) => {
   if (!related) return <div>No related bills</div>;
   return (
     <div>
+      <h4>Related Bills</h4>
       {Object.values(related).map((bill) => (
         <div key={bill.printNo}>
           <a href={`/bill/${bill.session}/${bill.printNo}`}>{bill.printNo}</a>:{' '}
@@ -18,18 +31,6 @@ const RelatedBills = ({ related }) => {
 RelatedBills.propTypes = {
   related: PropTypes.object.isRequired,
 };
-
-function getSponsorNumber(billData) {
-  const {
-    activeVersion,
-    amendments: { items },
-  } = billData;
-  return (
-    1 +
-    items[activeVersion].coSponsors.size +
-    items[activeVersion].multiSponsors.size
-  );
-}
 
 export const Bill = () => {
   const { sessionYear, printNo } = useParams();

--- a/frontend/src/components/Bill/Bill.jsx
+++ b/frontend/src/components/Bill/Bill.jsx
@@ -1,53 +1,77 @@
-import {PropTypes} from "prop-types";
-import {useState, useEffect} from "react";
-import { useParams } from "react-router-dom";
+import { PropTypes } from 'prop-types';
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 
-const RelatedBills = ({related}) => {
+const RelatedBills = ({ related }) => {
   if (!related) return <div>No related bills</div>;
   return (
     <div>
-      {Object.values(related).map((bill) => (<div key={bill.printNo}><a href={`/bill/${bill.session}/${bill.printNo}`}>{bill.printNo}</a>: {bill.title}</div>))}
+      {Object.values(related).map((bill) => (
+        <div key={bill.printNo}>
+          <a href={`/bill/${bill.session}/${bill.printNo}`}>{bill.printNo}</a>:{' '}
+          {bill.title}
+        </div>
+      ))}
     </div>
   );
-  };
+};
 RelatedBills.propTypes = {
   related: PropTypes.object.isRequired,
 };
 
 function getSponsorNumber(billData) {
-  const { activeVersion, amendments: { items } } = billData;
-  return 1 + items[activeVersion].coSponsors.size + items[activeVersion].multiSponsors.size;
+  const {
+    activeVersion,
+    amendments: { items },
+  } = billData;
+  return (
+    1 +
+    items[activeVersion].coSponsors.size +
+    items[activeVersion].multiSponsors.size
+  );
 }
 
 export const Bill = () => {
-  const {sessionYear, printNo} = useParams();
+  const { sessionYear, printNo } = useParams();
   const [bill, setBill] = useState();
 
   useEffect(() => {
-    const fetchBill = async() => {
+    const fetchBill = async () => {
       const res = await fetch(`/api/v1/bills/${sessionYear}/${printNo}`);
       await setBill(await res.json());
     };
     fetchBill();
   }, []);
 
-  if (!bill) return (
-    <div>
-      <div>This is the bill {printNo}&apos;s page</div>
-    </div>
-  );
+  if (!bill)
+    return (
+      <div>
+        <div>This is the bill {printNo}&apos;s page</div>
+      </div>
+    );
 
-  const {title, summary, sponsor: {member: {memberId: sponsorId, fullName: sponsorName}}} = bill;
+  const {
+    title,
+    summary,
+    sponsor: {
+      member: { memberId: sponsorId, fullName: sponsorName },
+    },
+  } = bill;
 
   return (
     <div>
       <div>This is the bill {printNo}&apos;s page</div>
       <h2>{title}</h2>
       <p>{summary}</p>
-      <div><span>{sponsorName}:{sponsorId}</span></div>
-      <div><span>Total Sponsors: {getSponsorNumber(bill)}</span></div>
+      <div>
+        <span>
+          {sponsorName}:{sponsorId}
+        </span>
+      </div>
+      <div>
+        <span>Total Sponsors: {getSponsorNumber(bill)}</span>
+      </div>
       <RelatedBills related={bill.billInfoRefs.items} />
     </div>
   );
-
 };

--- a/frontend/src/components/Bill/Bill.jsx
+++ b/frontend/src/components/Bill/Bill.jsx
@@ -32,10 +32,49 @@ RelatedBills.propTypes = {
   related: PropTypes.object.isRequired,
 };
 
+const BillCommitteeMembers = ({ committee, memberId, isSenate }) => {
+  // TODO: better styling
+  if (!isSenate) return <div>Assembly committees not currently supported</div>;
+  if (!committee) return <div>No committee data</div>;
+  console.log('committee');
+  console.log(committee);
+  const members = committee.committeeMembers.items.filter(
+    (m) => m.memberId !== memberId
+  );
+
+  return (
+    <div>
+      <h4>Committee: {committee.name} </h4>
+      <div>
+        {members.map((member) => (
+          <div key={member.memberId}>
+            <span>
+              {member.fullName}:{member.memberId}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div>
+        <span>Total Committee Members: {members.length}</span>
+      </div>
+    </div>
+  );
+};
+BillCommitteeMembers.propTypes = {
+  committee: PropTypes.object.isRequired,
+  memberId: PropTypes.string.isRequired,
+  isSenate: PropTypes.bool.isRequired,
+};
+
 export const Bill = () => {
   const { sessionYear, printNo } = useParams();
   const [bill, setBill] = useState();
+  const [committee, setCommittee] = useState();
 
+  const fetched = !!bill;
+  const isSenate = bill?.billType?.chamber?.toLowerCase() === 'senate';
+
+  // Fetch main bill data
   useEffect(() => {
     const fetchBill = async () => {
       const res = await fetch(`/api/v1/bills/${sessionYear}/${printNo}`);
@@ -43,6 +82,23 @@ export const Bill = () => {
     };
     fetchBill();
   }, []);
+
+  // Fetch bill committee data
+  useEffect(() => {
+    if (!fetched || !isSenate) return;
+    const chamber = bill.billType.chamber.toLowerCase();
+    const committee = bill?.status?.committeeName;
+    if (!committee) return;
+
+    const fetchCommittee = async () => {
+      const res = await fetch(
+        `/api/v1/committees/${sessionYear}/${chamber}/${committee}`
+      );
+      setCommittee(await res.json());
+    };
+
+    fetchCommittee();
+  }, [bill, sessionYear]);
 
   if (!bill)
     return (
@@ -73,6 +129,13 @@ export const Bill = () => {
         <span>Total Sponsors: {getSponsorNumber(bill)}</span>
       </div>
       <RelatedBills related={bill.billInfoRefs.items} />
+      {fetched && (
+        <BillCommitteeMembers
+          committee={committee}
+          memberId={sponsorId}
+          isSenate={isSenate}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
NOTE: the API only shows senate committees atm, not assembly. I emailed them, awaiting a response.

**To test:**
Visit page for a single bill.
Senate bill: should see committee & committee members at bottom
Assembly bill: should see "Assembly committees not currently supported" note

You can see the committee json by visiting the appropriate url, eg:
ex: `http://localhost:5173/api/v1/committees/2023/senate/Transportation`