### PR TITLE
Feature/filter by category

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -73,11 +73,6 @@ app.get('/api/v1/bills/:year/search', async (req, res, next) => {
   }
 });
 
-// todo: legacy, delete
-// app.get('/api/v1/bills/category-mappings', async (_, res) => {
-//   res.json(categoryMapping());
-// });
-
 // TODO: rename endpoint something more appropriate
 app.get('/api/v1/bills/airtable-bills', async (_, res) => {
   res.json(await fetchSunriseBills());

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -72,10 +72,10 @@ app.get('/api/v1/bills/:year/search', async (req, res, next) => {
   } else {
     // filter bills by category
     if (categories) {
-      const categoryFilters = categories.split(',')
+      const categoryFilters = categories.split(',');
       // TODO: ensure resultant size matches limit, if enough bills across all pages match
       out.result.items = out.result.items.filter((bill) =>
-      categoryFilters.some((categoryToFilter) =>
+        categoryFilters.some((categoryToFilter) =>
           categoryMapping()[bill.result.basePrintNo]?.includes(categoryToFilter)
         )
       );
@@ -86,10 +86,10 @@ app.get('/api/v1/bills/:year/search', async (req, res, next) => {
   }
 });
 
-// Mapping from bill id to category
-app.get('/api/v1/bills/category-mappings', async (_, res) => {
-  res.json(categoryMapping());
-});
+// todo: legacy, delete
+// app.get('/api/v1/bills/category-mappings', async (_, res) => {
+//   res.json(categoryMapping());
+// });
 
 // TODO: rename endpoint something more appropriate
 app.get('/api/v1/bills/airtable-bills', async (_, res) => {

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,7 +4,7 @@ import express from 'express';
 import fetch from 'node-fetch';
 
 import { legApi, membersFromYear } from './nysenate-api.js';
-import { categories, categoryMapping } from './categories.js';
+import { categories } from './categories.js';
 import { openStatesApi } from './openstates-api.js';
 import { mapBoxApi } from './mapbox-api.js';
 import { fetchSunriseBills } from './airtable-api.js';
@@ -43,7 +43,6 @@ app.get('/api/v1/bills/:year/search', async (req, res, next) => {
   const offset = req.query.offset || 1;
   const sort = '_score:desc,session:desc'; // taken from leg-API sample app
   const term = req.query.term || '*';
-  const categories = req.query.categories; // comma-separated list of strings (e.g. 'fix-mta,renews,ofw')
 
   if (process.env.MOCK_DATA === 'true') {
     const file = fs.readFileSync(`mock/search.json`).toString();
@@ -70,18 +69,6 @@ app.get('/api/v1/bills/:year/search', async (req, res, next) => {
       'Did not successfully retrieve bills from legislation.nysenate.gov. Response from API was marked as a failure.'
     );
   } else {
-    // filter bills by category
-    if (categories) {
-      const categoryFilters = categories.split(',');
-      // TODO: ensure resultant size matches limit, if enough bills across all pages match
-      out.result.items = out.result.items.filter((bill) =>
-        categoryFilters.some((categoryToFilter) =>
-          categoryMapping()[bill.result.basePrintNo]?.includes(categoryToFilter)
-        )
-      );
-      out.result.size = out.result.items.length;
-      out.total = out.result.items.length;
-    }
     res.json(out);
   }
 });

--- a/backend/src/categories.js
+++ b/backend/src/categories.js
@@ -57,6 +57,8 @@ export const categoryMapping = () => {
   // However, there is no leading zero from the api
   // eg, https://legislation.nysenate.gov/bills/2023/S2016
   return {
+    // TODO: REMOVE BEFORE MERGING
+    A2229: ['renews'],
     S2016: ['renews'],
     S2935B: ['renews'],
     S2129: ['renews'],

--- a/backend/src/categories.js
+++ b/backend/src/categories.js
@@ -57,8 +57,6 @@ export const categoryMapping = () => {
   // However, there is no leading zero from the api
   // eg, https://legislation.nysenate.gov/bills/2023/S2016
   return {
-    // TODO: REMOVE BEFORE MERGING
-    A2229: ['renews'],
     S2016: ['renews'],
     S2935B: ['renews'],
     S2129: ['renews'],

--- a/frontend/src/components/HomePage/Card.jsx
+++ b/frontend/src/components/HomePage/Card.jsx
@@ -1,10 +1,12 @@
+import PropTypes from 'prop-types';
+
 import CategoryTag from '../Category/CategoryTag';
 
-const Card = ({ bill, billCategoryMappings, allCategories }) => {
+const Card = ({ bill, billCampaignMappings, allCampaigns }) => {
   let categories = [];
-  if (billCategoryMappings && allCategories) {
-    categories = billCategoryMappings
-      .map((abrv) => allCategories[abrv].short_name)
+  if (billCampaignMappings && allCampaigns) {
+    categories = billCampaignMappings
+      .map((abrv) => allCampaigns[abrv].short_name)
       .filter((v) => !!v);
   }
   return (
@@ -28,6 +30,11 @@ const Card = ({ bill, billCategoryMappings, allCategories }) => {
       )}
     </a>
   );
+};
+Card.propTypes = {
+  bill: PropTypes.object.isRequired,
+  billCampaignMappings: PropTypes.arrayOf(PropTypes.string).isRequired,
+  allCampaigns: PropTypes.object.isRequired,
 };
 
 export default Card;

--- a/frontend/src/components/HomePage/Filters.css
+++ b/frontend/src/components/HomePage/Filters.css
@@ -2,3 +2,7 @@
   display: inline-flex;
   flex-direction: row;
 }
+
+.MuiMenuItem-root.Mui-selected {
+  background-color: rgba(25, 118, 210, 0.3)
+}

--- a/frontend/src/components/HomePage/Filters.jsx
+++ b/frontend/src/components/HomePage/Filters.jsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { TAGS, BILL_STATUSES, SEARCH_QUERY_KEY_MAP } from '../../constants';
+import { BILL_STATUSES, SEARCH_QUERY_KEY_MAP } from '../../constants';
 import Dropdown from './Dropdown';
 import './Filters.css';
 
-const Filters = ({ setSearchTerm }) => {
+const Filters = ({ categoryList, setSearchTerm, setCategoryFilter }) => {
   // creates ElasticSearch query string
   const [searchTermsObj, setSearchTermsObj] = useState({});
 
@@ -70,16 +70,19 @@ const Filters = ({ setSearchTerm }) => {
       <Dropdown
         id="category-select"
         label="Bill Category"
-        options={TAGS.map((tag) => ({
-          displayName: tag,
-          value: tag,
+        options={categoryList.map((category) => ({
+          displayName: category,
+          value: category,
         }))}
+        updateFilter={setCategoryFilter}
       />
     </div>
   );
 };
 
 Filters.propTypes = {
+  categoryList: PropTypes.arrayOf(PropTypes.string).isRequired,
+  setCategoryFilter: PropTypes.func.isRequired,
   setSearchTerm: PropTypes.func.isRequired,
 };
 

--- a/frontend/src/components/HomePage/Filters.jsx
+++ b/frontend/src/components/HomePage/Filters.jsx
@@ -5,7 +5,7 @@ import { BILL_STATUSES, SEARCH_QUERY_KEY_MAP } from '../../constants';
 import Dropdown from './Dropdown';
 import './Filters.css';
 
-const Filters = ({ categoryList, setSearchTerm, setCategoryFilter }) => {
+const Filters = ({ campaignList, setSearchTerm, setCampaignFilter }) => {
   // creates ElasticSearch query string
   const [searchTermsObj, setSearchTermsObj] = useState({});
 
@@ -70,19 +70,19 @@ const Filters = ({ categoryList, setSearchTerm, setCategoryFilter }) => {
       <Dropdown
         id="category-select"
         label="Bill Category"
-        options={categoryList.map((category) => ({
-          displayName: category,
-          value: category,
+        options={campaignList.map((campaign) => ({
+          displayName: campaign.short_name,
+          value: campaign.id,
         }))}
-        updateFilter={setCategoryFilter}
+        updateFilter={setCampaignFilter}
       />
     </div>
   );
 };
 
 Filters.propTypes = {
-  categoryList: PropTypes.arrayOf(PropTypes.string).isRequired,
-  setCategoryFilter: PropTypes.func.isRequired,
+  campaignList: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setCampaignFilter: PropTypes.func.isRequired,
   setSearchTerm: PropTypes.func.isRequired,
 };
 

--- a/frontend/src/components/HomePage/index.jsx
+++ b/frontend/src/components/HomePage/index.jsx
@@ -8,17 +8,9 @@ import Filters from './Filters';
 const HomePage = () => {
   const [bills, setBills] = useState([]);
   const [searchTerm, setSearchTerm] = useState('*');
-  const [_campaignMappings, setCampaignMappings] = useState({});
+  const [campaignMappings, setCampaignMappings] = useState({});
   const [campaigns, setCampaigns] = useState({});
   const [campaignFilter, setCampaignFilter] = useState([]);
-
-  // TODO: remove after review
-  const campaignMappings = Object.keys(_campaignMappings).length
-    ? {
-        ..._campaignMappings,
-        A2229: ['recaKM8EyeUejwpBf'],
-      }
-    : _campaignMappings;
 
   const billsToDisplay = campaignFilter.length
     ? bills.filter((bill) =>

--- a/frontend/src/components/HomePage/index.jsx
+++ b/frontend/src/components/HomePage/index.jsx
@@ -12,6 +12,14 @@ const HomePage = () => {
   const [campaigns, setCampaigns] = useState({});
   const [campaignFilter, setCampaignFilter] = useState([]);
 
+  const billsToDisplay = campaignFilter.length
+    ? bills.filter((bill) =>
+        campaignMappings[bill.basePrintNo]?.some((relatedCampaignId) =>
+          campaignFilter.includes(relatedCampaignId)
+        )
+      )
+    : bills;
+
   const campaignList = Object.values(campaigns);
 
   // fetch bills
@@ -29,7 +37,6 @@ const HomePage = () => {
           const queryStr = new URLSearchParams({
             offset,
             term: searchTerm,
-            // categories: campaignFilter?.join(','), // fixme
           }).toString();
           const res = await fetch(`/api/v1/bills/2023/search?${queryStr}`, {
             signal: abortController.signal,
@@ -53,7 +60,7 @@ const HomePage = () => {
       abortController.abort();
       setBills([]);
     };
-  }, [campaignFilter, searchTerm]);
+  }, [searchTerm]);
 
   // Fetch campaign mappings and campaigns
   useEffect(() => {
@@ -94,7 +101,7 @@ const HomePage = () => {
           setSearchTerm={setSearchTerm}
         />
         <div id="home-bill-grid">
-          {bills.map((bill) => (
+          {billsToDisplay.map((bill) => (
             <Card
               bill={bill}
               key={bill.basePrintNoStr}

--- a/frontend/src/components/HomePage/index.jsx
+++ b/frontend/src/components/HomePage/index.jsx
@@ -10,6 +10,9 @@ const HomePage = () => {
   const [searchTerm, setSearchTerm] = useState('*');
   const [categoryMappings, setCategoryMappings] = useState({});
   const [categories, setCategories] = useState({});
+  const [categoryFilter, setCategoryFilter] = useState([]);
+
+  const categoryList = Object.keys(categories);
 
   // fetch bills
   useEffect(() => {
@@ -26,6 +29,7 @@ const HomePage = () => {
           const queryStr = new URLSearchParams({
             offset,
             term: searchTerm,
+            categories: categoryFilter?.join(','),
           }).toString();
           const res = await fetch(`/api/v1/bills/2023/search?${queryStr}`, {
             signal: abortController.signal,
@@ -49,7 +53,7 @@ const HomePage = () => {
       abortController.abort();
       setBills([]);
     };
-  }, [searchTerm]);
+  }, [categoryFilter, searchTerm]);
 
   // fetch category mappings and categories
   useEffect(() => {
@@ -93,7 +97,11 @@ const HomePage = () => {
       <Banner />
       <div id="home-page">
         <h1>Sunrise featured bills</h1>
-        <Filters setSearchTerm={setSearchTerm} />
+        <Filters
+          categoryList={categoryList}
+          setCategoryFilter={setCategoryFilter}
+          setSearchTerm={setSearchTerm}
+        />
         <div id="home-bill-grid">
           {bills.map((bill) => (
             <Card

--- a/frontend/src/components/HomePage/index.jsx
+++ b/frontend/src/components/HomePage/index.jsx
@@ -8,9 +8,17 @@ import Filters from './Filters';
 const HomePage = () => {
   const [bills, setBills] = useState([]);
   const [searchTerm, setSearchTerm] = useState('*');
-  const [campaignMappings, setCampaignMappings] = useState({});
+  const [_campaignMappings, setCampaignMappings] = useState({});
   const [campaigns, setCampaigns] = useState({});
   const [campaignFilter, setCampaignFilter] = useState([]);
+
+  // TODO: remove after CR
+  const campaignMappings = Object.keys(_campaignMappings).length
+    ? {
+        ..._campaignMappings,
+        A2229: ['recaKM8EyeUejwpBf'],
+      }
+    : _campaignMappings;
 
   const billsToDisplay = campaignFilter.length
     ? bills.filter((bill) =>

--- a/frontend/src/components/HomePage/index.jsx
+++ b/frontend/src/components/HomePage/index.jsx
@@ -12,7 +12,7 @@ const HomePage = () => {
   const [campaigns, setCampaigns] = useState({});
   const [campaignFilter, setCampaignFilter] = useState([]);
 
-  // TODO: remove after CR
+  // TODO: remove after review
   const campaignMappings = Object.keys(_campaignMappings).length
     ? {
         ..._campaignMappings,

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,5 +1,3 @@
-export const TAGS = ['Climate', 'Social Justice', 'Education', 'LGBTQ'];
-
 export const BILL_STATUSES = [
   'Introduced',
   'In Senate Committee',


### PR DESCRIPTION
addresses https://github.com/sunrisemvmtnyc/legislation-tracker/issues/39

Filters bills by category on backend
- consolidates filtering within API
- however, the filter only extends to the initial bills within the `limit` number so may have to make additional bill requests to ensure we gather all bills after `limit` that match the filtered categories

Currently, no bills in the first 100 are in the categories so added a temp entry ('A2229' w/ 'renews' category)
