### PR TITLE
Keep footer always at bottom of the page

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -610,3 +610,13 @@ a:hover .callout__text {
 /*
   vim: foldmethod=marker
   */
+
+/* Keep footer always at the bottom of the page */
+#root {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.App {
+  flex: 1;
+}


### PR DESCRIPTION
Keeps the footer at the bottom of the page in case the content is smaller than the window height

(ex: home page while the bills are loading)

![image](https://github.com/sunrisemvmtnyc/legislation-tracker/assets/2589116/764dbf7d-c452-4c63-b005-f5f2aa10bf30)
