### PR TITLE
fix: better error handling when nysenate fetch fails

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -8,8 +8,6 @@ import { openStatesApi, openStatesGeoApi } from './openstates-api.js';
 import { mapBoxApi } from './mapbox-api.js';
 import { fetchSunriseBills } from './airtable-api.js';
 
-import fs from 'fs';
-
 // Create Express server
 const host = '0.0.0.0';
 const port = 3001;
@@ -50,19 +48,28 @@ app.get('/api/v1/bills/:year/search', async (req, res, next) => {
     term,
     limit,
   });
-  let out = await (await fetch(url)).json();
+  try {
+    const out = await (await fetch(url)).json();
 
-  if (!out.success) {
+    if (!out.success) {
+      // TODO: upgrade expressJS when v5 is stable
+      // https://expressjs.com/en/guide/error-handling.html
+      console.log('Failed bill request:');
+      console.log(out.message);
+      console.log(url);
+      next(
+        'Did not successfully retrieve bills from legislation.nysenate.gov. Response from API was marked as a failure.'
+      );
+    } else {
+      res.json(out);
+    }
+  } catch (err) {
     // TODO: upgrade expressJS when v5 is stable
     // https://expressjs.com/en/guide/error-handling.html
     console.log('Failed bill request:');
-    console.log(out.message);
+    console.error(err);
     console.log(url);
-    next(
-      'Did not successfully retrieve bills from legislation.nysenate.gov. Response from API was marked as a failure.'
-    );
-  } else {
-    res.json(out);
+    next('Error requesting legislation.nysenate.gov');
   }
 });
 


### PR DESCRIPTION
The app would crash when I was on a VPN. Now it still throws a 500, but doesn't crash.

**To test**: Just make sure the regular query still works.